### PR TITLE
Maintain compatibility with Kokkos 5.2+

### DIFF
--- a/cmake.d/setup/Kokkos.cmake
+++ b/cmake.d/setup/Kokkos.cmake
@@ -101,7 +101,9 @@ if(QUICC_USE_KOKKOS)
             )
         endif()
         message(VERBOSE "Kokkos CUDA Enabled = ${Kokkos_ENABLE_CUDA}")
-        kokkos_check(OPTIONS CUDA_LAMBDA)
+		if(Kokkos_VERSION VERSION_LESS 4.1)
+          kokkos_check(OPTIONS CUDA_LAMBDA)
+		endif()
 
         # get cuda flags from the wrapper
         # alternatively we can strip Kokkos_INTERFACE_COMPILE_OPTIONS


### PR DESCRIPTION
The CUDA_LAMBDA option is deprecated and always ON since Kokkos 4.1 and is scheduled for removal in the (upcoming) Kokkos 5.2 release.